### PR TITLE
Add custom icons using hook

### DIFF
--- a/wp-social-networks-.php
+++ b/wp-social-networks-.php
@@ -102,7 +102,7 @@ if (!class_exists('WPSocialNetworksWidget')) {
          * @since 2.0.0
          */
         protected function get_social_networks() {
-            return array(
+            $icons = array(
                 'facebook' => array(
                     'icon' => 'facebook',
                     'label' => '',
@@ -204,6 +204,12 @@ if (!class_exists('WPSocialNetworksWidget')) {
                     'url' => ''
                 ),
             );
+            
+            /*
+            * Add custom icons 
+            * @author hadi khosrojerdi
+            */
+            return apply_filters( "wp_social_netwoks_widget_icons", $icons );
         }
 
         /**


### PR DESCRIPTION
Developers can add their custom fonicons using this hook, for example :

``` php

function my_fonticons(  $icons ){

      // fontawesome icons
      $icons['facebook'] = array(
                    'icon' => 'fa fa-facebook',
                    'label' => '',
                    'url' => ''
       );

       $icons['github'] = array(
                    'icon' => 'fa fa-github',
                    'label' => '',
                    'url' => ''
       );

       $icons['bitbucket'] = array(
                    'icon' => 'fa fa-bitbucket',
                    'label' => '',
                    'url' => ''
       );

      return $icons;
}
add_filter("wp_social_netwoks_widget_icons", "my_fonticons");

```
